### PR TITLE
Add async cache to quiz generator

### DIFF
--- a/feature_proposal_ai.md
+++ b/feature_proposal_ai.md
@@ -6,3 +6,10 @@
 - Cache fetched Wikipedia summaries to reduce repeated network calls.
 - Preload trending topics asynchronously for quicker access.
 - Track user progress over time with detailed analytics.
+
+## Additional Suggestions
+
+- **Collaborative Challenges** – Let learners compete or cooperate on quizzes in real time.
+- **Adaptive Difficulty** – Adjust question complexity dynamically based on past performance.
+- **Gamification** – Award badges or points for completing lessons to increase engagement.
+- **Multilingual Support** – Provide translations of content and quizzes for global audiences.

--- a/quiz_engine.py
+++ b/quiz_engine.py
@@ -1,18 +1,39 @@
 import os
-from functools import lru_cache
 import asyncio
+from typing import Dict, Tuple
 import openai
+
 
 CACHE_SIZE = int(os.getenv("CACHE_SIZE", 128))
 RATE_LIMIT = int(os.getenv("RATE_LIMIT", 5))
 _semaphore = asyncio.Semaphore(RATE_LIMIT)
 
-@lru_cache(maxsize=CACHE_SIZE)
+# Simple async-aware in-memory cache
+_cache: Dict[Tuple[str, int], str] = {}
+_cache_lock = asyncio.Lock()
+
+async def clear_cache() -> None:
+    """Clear the quiz cache."""
+    async with _cache_lock:
+        _cache.clear()
+
 async def generate_quiz(summary: str, n_questions: int = 3):
+    key = (summary, n_questions)
+    async with _cache_lock:
+        if key in _cache:
+            return _cache[key]
+
     prompt = (
         f"Generate {n_questions} multiple choice questions with answers based on the following text:\n{summary}"
     )
     async with _semaphore:
         resp = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role":"user","content":prompt}])
     content = resp.choices[0].message['content']
+
+    async with _cache_lock:
+        if len(_cache) >= CACHE_SIZE:
+            # drop the first inserted item (FIFO) when cache is full
+            _cache.pop(next(iter(_cache)))
+        _cache[key] = content
+
     return content

--- a/tests/test_quiz_engine.py
+++ b/tests/test_quiz_engine.py
@@ -1,5 +1,5 @@
 import asyncio
-from quiz_engine import generate_quiz
+from quiz_engine import generate_quiz, clear_cache
 
 def test_generate_quiz(monkeypatch):
     def fake_create(model, messages):
@@ -8,5 +8,25 @@ def test_generate_quiz(monkeypatch):
 
         return R()
     monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
+    asyncio.run(clear_cache())
     res = asyncio.run(generate_quiz("Python is great."))
     assert "Q1" in res
+
+
+def test_generate_quiz_cached(monkeypatch):
+    calls = []
+
+    def fake_create(model, messages):
+        calls.append(1)
+        class R:
+            choices = [type("X", (), {"message": {"content": "Q2"}})]
+
+        return R()
+
+    monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
+    asyncio.run(clear_cache())
+    first = asyncio.run(generate_quiz("Cache me"))
+    second = asyncio.run(generate_quiz("Cache me"))
+    assert first == "Q2"
+    assert second == "Q2"
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- implement manual async-aware cache in `quiz_engine`
- extend tests to ensure cached calls reuse quiz results
- propose several new features in `feature_proposal_ai.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5b8e6ff4832bb9d706015719ebbc

## Summary by Sourcery

Add an async-aware in-memory cache to the quiz generator, support cache clearing, update tests to verify caching behavior, and extend AI feature proposals in documentation.

Enhancements:
- Implement a manual async-aware cache with FIFO eviction in quiz_engine.generate_quiz
- Add an async clear_cache function to reset the quiz cache

Documentation:
- Append additional AI-powered feature suggestions to feature_proposal_ai.md

Tests:
- Extend tests to clear the cache before running generate_quiz
- Add a test to ensure cached calls reuse results and prevent duplicate API calls