### PR TITLE
Fix pytest collection issue

### DIFF
--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -1,4 +1,5 @@
 class TestClient:
+    __test__ = False
     def __init__(self, app):
         self.app = app
 

--- a/feature_proposal_ai.md
+++ b/feature_proposal_ai.md
@@ -6,3 +6,6 @@
 - Cache fetched Wikipedia summaries to reduce repeated network calls.
 - Preload trending topics asynchronously for quicker access.
 - Track user progress over time with detailed analytics.
+- Introduce collaborative quiz sessions where users can compete in real time.
+- Gamify lessons with badges and experience levels to boost engagement.
+- Provide offline mode so learners can download content and sync progress later.


### PR DESCRIPTION
## Summary
- mark `TestClient` as not a test so pytest won't collect it
- expand AI feature proposal with new collaborative and gamification ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f592c4d60832bb00ad578a31268d1

## Summary by Sourcery

Mark TestClient as non-test for pytest collection and enhance AI feature proposal with collaborative, gamification, and offline functionalities

Bug Fixes:
- Mark TestClient with __test__ = False to prevent pytest from collecting it

Documentation:
- Add collaborative quiz sessions, gamification badges/levels, and offline mode to the AI feature proposal